### PR TITLE
Feat: router

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,18 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Login, PageA, PageB, PageC } from './pages';
 import { MainLayout } from '@/components';
+import { PAGE_ROUTE } from './consts';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route element={<MainLayout />}>
-          <Route path="/pageA" element={<PageA />} />
-          <Route path="/pageB" element={<PageB />} />
-          <Route path="/pageC" element={<PageC />} />
+          <Route path={PAGE_ROUTE.PAGE_A} element={<PageA />} />
+          <Route path={PAGE_ROUTE.PAGE_B} element={<PageB />} />
+          <Route path={PAGE_ROUTE.PAGE_B} element={<PageC />} />
         </Route>
-        <Route path="/login" element={<Login />} />
+        <Route path={PAGE_ROUTE.LOGIN} element={<Login />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,20 @@
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { Login, PageA, PageB, PageC } from './pages';
+import { MainLayout } from '@/components';
+
 function App() {
-  return <div>react</div>;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route element={<MainLayout />}>
+          <Route path="/pageA" element={<PageA />} />
+          <Route path="/pageB" element={<PageB />} />
+          <Route path="/pageC" element={<PageC />} />
+        </Route>
+        <Route path="/login" element={<Login />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/components/common/MainLayout/MainLayout.tsx
+++ b/src/components/common/MainLayout/MainLayout.tsx
@@ -1,0 +1,13 @@
+import { Header } from '@/components';
+import { Outlet } from 'react-router-dom';
+
+function MainLayout() {
+  return (
+    <>
+      <Header />
+      <Outlet />
+    </>
+  );
+}
+
+export default MainLayout;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,1 +1,2 @@
 export { default as Header } from './Header/Header';
+export { default as MainLayout } from './MainLayout/MainLayout';

--- a/src/consts/index.ts
+++ b/src/consts/index.ts
@@ -1,0 +1,1 @@
+export * from './route';

--- a/src/consts/route.ts
+++ b/src/consts/route.ts
@@ -1,0 +1,7 @@
+export const PAGE_ROUTE = {
+  HOME: '/',
+  LOGIN: '/login',
+  PAGE_A: '/pageA',
+  PAGE_B: '/pageB',
+  PAGE_C: '/pageC',
+};

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,0 +1,7 @@
+import * as S from './LoginStyle';
+
+function Login() {
+  return <S.Login>login</S.Login>;
+}
+
+export default Login;

--- a/src/pages/Login/LoginStyle.ts
+++ b/src/pages/Login/LoginStyle.ts
@@ -1,0 +1,10 @@
+import { styled } from '@stitches/react';
+
+export const Login = styled('div', {
+  color: 'salmon',
+  height: '100vh',
+  display: 'flex',
+  flexFlow: 'column wrap',
+  justifyContent: 'center',
+  alignItems: 'center',
+});

--- a/src/pages/PageA/PageA.tsx
+++ b/src/pages/PageA/PageA.tsx
@@ -1,0 +1,7 @@
+import * as S from './PageAStyle';
+
+function PageA() {
+  return <S.PageA>PAGE A</S.PageA>;
+}
+
+export default PageA;

--- a/src/pages/PageA/PageAStyle.ts
+++ b/src/pages/PageA/PageAStyle.ts
@@ -1,0 +1,6 @@
+import { styled } from '@stitches/react';
+
+export const PageA = styled('main', {
+  textAlign: 'center',
+  color: 'red',
+});

--- a/src/pages/PageB/PageB.tsx
+++ b/src/pages/PageB/PageB.tsx
@@ -1,0 +1,7 @@
+import * as S from './PageBStyle';
+
+function PageB() {
+  return <S.PageBStyle>PAGE B</S.PageBStyle>;
+}
+
+export default PageB;

--- a/src/pages/PageB/PageBStyle.ts
+++ b/src/pages/PageB/PageBStyle.ts
@@ -1,0 +1,6 @@
+import { styled } from '@stitches/react';
+
+export const PageBStyle = styled('main', {
+  textAlign: 'center',
+  color: 'blue',
+});

--- a/src/pages/PageC/PageC.tsx
+++ b/src/pages/PageC/PageC.tsx
@@ -1,0 +1,7 @@
+import * as S from './PageCStyle';
+
+function PageC() {
+  return <S.PageCStyle>PAGE C</S.PageCStyle>;
+}
+
+export default PageC;

--- a/src/pages/PageC/PageCStyle.ts
+++ b/src/pages/PageC/PageCStyle.ts
@@ -1,0 +1,6 @@
+import { styled } from '@stitches/react';
+
+export const PageCStyle = styled('main', {
+  textAlign: 'center',
+  color: 'green',
+});

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,4 @@
+export { default as PageA } from './PageA/PageA';
+export { default as PageB } from './PageB/PageB';
+export { default as PageC } from './PageC/PageC';
+export { default as Login } from './Login/Login';


### PR DESCRIPTION
## 작업 사항
- react router dom을 사용하여 route 설정 9f9734e
- page A, page B, page C, login 페이지 구현 46ce046 fa07f44 3ffe719
<img width="600" alt="스크린샷 2023-03-06 오전 11 47 45" src="https://user-images.githubusercontent.com/61978339/223008013-a8a2a69a-473a-4568-9d9c-1287e0eaf463.png"></br>
- react router dom의 outlet을 사용하여 page A, pageB, page C에서만 공통 헤더를 가짐 ce66f59
- route 상수를 추가해 page path 관리 e26a553 5ff5d7e